### PR TITLE
Added Floating Action Button in HomeScreen

### DIFF
--- a/silen_shh/lib/screens/HomeScreen.dart
+++ b/silen_shh/lib/screens/HomeScreen.dart
@@ -10,8 +10,8 @@ import 'package:sound_mode/sound_mode.dart';
 import 'package:sound_mode/utils/sound_profiles.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:highlighter_coachmark/highlighter_coachmark.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:unicorndial/unicorndial.dart';
 
 class HomeScreen extends StatefulWidget {
   @override
@@ -54,34 +54,38 @@ class _MyAppState extends State<HomeScreen> {
     });
   }
 
-  Widget button1() {
-    return Container(
-      child: FloatingActionButton(
-        onPressed: null,
-        heroTag: 'Add by WiFi',
-        tooltip: 'Add by WiFi',
-        child: Icon(Icons.wifi),
-        backgroundColor: Colors.indigo[300],
-      ),
-    );
-  }
-
-  Widget button2() {
-    return Container(
-      child: FloatingActionButton(
-        onPressed: null,
-        heroTag: 'Add by Time',
-        tooltip: 'Add by Time',
-        child: Icon(Icons.add),
-        //label: Text('Add by Time'),
-
-        backgroundColor: Colors.indigo[300],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
+    var childButtons = List<UnicornButton>();
+
+    childButtons.add(
+      UnicornButton(
+        hasLabel: true,
+        labelText: "Add by WiFi",
+        currentButton: FloatingActionButton(
+          heroTag: "wifi",
+          mini: true,
+          backgroundColor: Colors.indigo[300],
+          child: Icon(Icons.wifi),
+          onPressed: () {},
+        ),
+      ),
+    );
+
+    childButtons.add(
+      UnicornButton(
+        hasLabel: true,
+        labelText: "Add by Time",
+        currentButton: FloatingActionButton(
+          onPressed: () {},
+          heroTag: "time",
+          mini: true,
+          backgroundColor: Colors.indigo[300],
+          child: Icon(Icons.event),
+        ),
+      ),
+    );
+
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(
@@ -165,39 +169,12 @@ class _MyAppState extends State<HomeScreen> {
             ],
           ),
         ),
-        floatingActionButton: SpeedDial(
-          marginBottom: 20.0,
-          marginRight: 18.0,
-          animatedIcon: AnimatedIcons.menu_close,
-          //animatedIconTheme: IconThemeData(size: 22.0),
-          curve: Curves.bounceIn,
-          overlayColor: Colors.grey[800],
-          overlayOpacity: 0.8,
-          onOpen: () => print('OPENING DIAL'),
-          onClose: () => print('DIAL CLOSED'),
-          tooltip: 'Speed Dial',
-          heroTag: 'speed-dial-hero-tag',
-          backgroundColor: Colors.indigo[300],
-          foregroundColor: Colors.white,
-          elevation: 8.0,
-          shape: CircleBorder(),
-          children: [
-            SpeedDialChild(
-              child: Icon(Icons.timer),
-              backgroundColor: Colors.indigo[300],
-              label: 'Add by Time',
-              labelStyle: TextStyle(fontSize: 18.0),
-              onTap: () => print('SECOND CHILD'),
-            ),
-            SpeedDialChild(
-              child: Icon(Icons.wifi),
-              backgroundColor: Colors.indigo[300],
-              label: 'Add by WiFi',
-              labelStyle: TextStyle(fontSize: 18.0),
-              onTap: () => print('FIRST CHILD'),
-            ),
-          ],
-        ),
+        floatingActionButton: UnicornDialer(
+            backgroundColor: Color.fromRGBO(0, 0, 0, 0.8),
+            parentButtonBackground: Colors.indigo[300],
+            orientation: UnicornOrientation.VERTICAL,
+            parentButton: Icon(Icons.add),
+            childButtons: childButtons),
       ),
     );
   }

--- a/silen_shh/lib/screens/HomeScreen.dart
+++ b/silen_shh/lib/screens/HomeScreen.dart
@@ -1,6 +1,7 @@
 // This code shows basic implementation of sound modes
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:share/share.dart';
@@ -8,6 +9,9 @@ import 'package:sound_mode/permission_handler.dart';
 import 'package:sound_mode/sound_mode.dart';
 import 'package:sound_mode/utils/sound_profiles.dart';
 import 'package:url_launcher/url_launcher.dart';
+
+import 'package:highlighter_coachmark/highlighter_coachmark.dart';
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 
 class HomeScreen extends StatefulWidget {
   @override
@@ -48,6 +52,32 @@ class _MyAppState extends State<HomeScreen> {
       _permissionStatus =
           permissionStatus ? "Permissions Enabled" : "Permissions not granted";
     });
+  }
+
+  Widget button1() {
+    return Container(
+      child: FloatingActionButton(
+        onPressed: null,
+        heroTag: 'Add by WiFi',
+        tooltip: 'Add by WiFi',
+        child: Icon(Icons.wifi),
+        backgroundColor: Colors.indigo[300],
+      ),
+    );
+  }
+
+  Widget button2() {
+    return Container(
+      child: FloatingActionButton(
+        onPressed: null,
+        heroTag: 'Add by Time',
+        tooltip: 'Add by Time',
+        child: Icon(Icons.add),
+        //label: Text('Add by Time'),
+
+        backgroundColor: Colors.indigo[300],
+      ),
+    );
   }
 
   @override
@@ -134,6 +164,39 @@ class _MyAppState extends State<HomeScreen> {
               ),
             ],
           ),
+        ),
+        floatingActionButton: SpeedDial(
+          marginBottom: 20.0,
+          marginRight: 18.0,
+          animatedIcon: AnimatedIcons.menu_close,
+          //animatedIconTheme: IconThemeData(size: 22.0),
+          curve: Curves.bounceIn,
+          overlayColor: Colors.grey[800],
+          overlayOpacity: 0.8,
+          onOpen: () => print('OPENING DIAL'),
+          onClose: () => print('DIAL CLOSED'),
+          tooltip: 'Speed Dial',
+          heroTag: 'speed-dial-hero-tag',
+          backgroundColor: Colors.indigo[300],
+          foregroundColor: Colors.white,
+          elevation: 8.0,
+          shape: CircleBorder(),
+          children: [
+            SpeedDialChild(
+              child: Icon(Icons.timer),
+              backgroundColor: Colors.indigo[300],
+              label: 'Add by Time',
+              labelStyle: TextStyle(fontSize: 18.0),
+              onTap: () => print('SECOND CHILD'),
+            ),
+            SpeedDialChild(
+              child: Icon(Icons.wifi),
+              backgroundColor: Colors.indigo[300],
+              label: 'Add by WiFi',
+              labelStyle: TextStyle(fontSize: 18.0),
+              onTap: () => print('FIRST CHILD'),
+            ),
+          ],
         ),
       ),
     );

--- a/silen_shh/lib/screens/SplashScreen.dart
+++ b/silen_shh/lib/screens/SplashScreen.dart
@@ -56,7 +56,7 @@ class _SplashScreenState extends State<SplashScreen> {
           ),
              Align(
                 alignment: Alignment.bottomCenter,
-                child: Text("Version 1.0")),
+                child: Text("Version 1.0"),),
         ],
       ),
     );

--- a/silen_shh/pubspec.lock
+++ b/silen_shh/pubspec.lock
@@ -79,13 +79,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  highlighter_coachmark:
-    dependency: "direct main"
-    description:
-      name: highlighter_coachmark
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.3"
   matcher:
     dependency: transitive
     description:
@@ -189,6 +182,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  unicorndial:
+    dependency: "direct main"
+    description:
+      name: unicorndial
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.5"
   url_launcher:
     dependency: "direct main"
     description:

--- a/silen_shh/pubspec.lock
+++ b/silen_shh/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -15,6 +15,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   charcode:
     dependency: transitive
     description:
@@ -35,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.13"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -55,6 +62,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_speed_dial:
+    dependency: "direct main"
+    description:
+      name: flutter_speed_dial
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.5"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -65,13 +79,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  highlighter_coachmark:
+    dependency: "direct main"
+    description:
+      name: highlighter_coachmark
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.8"
   meta:
     dependency: transitive
     description:
@@ -132,7 +153,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.9.5"
   stream_channel:
     dependency: transitive
     description:
@@ -160,14 +181,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.16"
+    version: "0.2.17"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.2.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/silen_shh/pubspec.yaml
+++ b/silen_shh/pubspec.yaml
@@ -29,6 +29,8 @@ dependencies:
   cupertino_icons: ^0.1.3
   share: ^0.6.5+2
   url_launcher: ^5.7.2
+  highlighter_coachmark: ^0.0.3
+  flutter_speed_dial: ^1.2.5
 
 dev_dependencies:
   flutter_test:

--- a/silen_shh/pubspec.yaml
+++ b/silen_shh/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   cupertino_icons: ^0.1.3
   share: ^0.6.5+2
   url_launcher: ^5.7.2
-  highlighter_coachmark: ^0.0.3
+  unicorndial: ^1.1.5
   flutter_speed_dial: ^1.2.5
 
 dev_dependencies:


### PR DESCRIPTION
17

<!-- Replace ISSUENUMBER with the concerned issue number without # -->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
<!-- Add issue numbers both above and below this comment, do not remove __ or #-->

Fixes #17 

### Precise description of what this resolves:
A Floating Action Button is added to Home Screen which also includes overlays like a background color and buttons to 'Add by WiFi' and 'Add by Time'


### Changes proposed in this PR and/or Screenshot(s) of changes:


- Initial FAB

![Screenshot_20201004-075046](https://user-images.githubusercontent.com/52914951/95005508-6137e680-0617-11eb-871e-93b8e4b9165f.png)


 - FAB options on clicking the initial FAB

![Screenshot_20201004-075550](https://user-images.githubusercontent.com/52914951/95005510-6a28b800-0617-11eb-9636-a262405e0390.png)

